### PR TITLE
Add overflow hidden to highlighted post style

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -162,6 +162,7 @@ header .profile .notifications_count {
     flex-direction: row;
     box-shadow: none;
     display: none;
+    overflow: hidden;
 }
 .article .highlighted .post:hover {
     box-shadow: none;


### PR DESCRIPTION
Added 'overflow: hidden' to the .article .highlighted .post CSS rule to ensure content does not overflow its container. This helps maintain layout integrity when the element is displayed.